### PR TITLE
Adding in missing _RESERVED values in HandshakeType

### DIFF
--- a/rfc8446.xml
+++ b/rfc8446.xml
@@ -830,7 +830,7 @@ processed and transmitted as specified by the current active connection state.</
        certificate_request(13),
        certificate_verify(15),
        finished(20),
-       certificate_URL_RESEREVED(21),
+       certificate_url_RESEREVED(21),
        certificate_status_RESERVED(22),
        supplemental_data_RESERVED(23),
        key_update(24),

--- a/rfc8446.xml
+++ b/rfc8446.xml
@@ -830,7 +830,7 @@ processed and transmitted as specified by the current active connection state.</
        certificate_request(13),
        certificate_verify(15),
        finished(20),
-       certificate_url_RESEREVED(21),
+       certificate_url_RESERVED(21),
        certificate_status_RESERVED(22),
        supplemental_data_RESERVED(23),
        key_update(24),

--- a/rfc8446.xml
+++ b/rfc8446.xml
@@ -830,6 +830,9 @@ processed and transmitted as specified by the current active connection state.</
        certificate_request(13),
        certificate_verify(15),
        finished(20),
+       certificate_URL_RESEREVED(21),
+       certificate_status_RESERVED(22),
+       supplemental_data_RESERVED(23),
        key_update(24),
        message_hash(254),
        (255)


### PR DESCRIPTION
Apologies if I'm doing this wrong.

I think these values should be included in the document.  They were specified in earlier versions and should be included but marked as reserved.