### PR TITLE
RFC 8422 Obsoletes RFC 4492

### DIFF
--- a/rfc8446.xml
+++ b/rfc8446.xml
@@ -13,7 +13,7 @@
 <?rfc text-list-symbols="-o*+"?>
 
 <rfc ipr="pre5378Trust200902" number="8446" category="std"
- obsoletes="5077, 5246, 6961" updates="4492, 5705, 6066"
+ obsoletes="5077, 5246, 6961" updates="5705, 6066"
  submissionType="IETF" consensus="yes">
 
   <front>
@@ -35,7 +35,7 @@
 over the Internet in a way that is designed to prevent eavesdropping,
 tampering, and message forgery.</t>
 
-<t>This document updates RFCs 4492, 5705, and 6066, and obsoletes
+<t>This document updates RFCs 5705, and 6066, and obsoletes
 RFCs 5077, 5246, and 6961. This document also specifies new
 requirements for TLS 1.2 implementations.</t>
 
@@ -107,9 +107,8 @@ negotiate a common version if one is supported by both peers.</t>
 <t>This document supersedes and obsoletes previous versions of TLS,
 including version 1.2 <xref target="RFC5246"/>.  It also obsoletes the TLS
 ticket mechanism defined in <xref target="RFC5077"/> and replaces it with the
-mechanism defined in <xref target="resumption-and-psk"/>. <xref
-target="negotiated-groups"/> updates <xref target="RFC4492"/> by modifying the
-protocol attributes used to negotiate elliptic curves.  Because TLS 1.3
+mechanism defined in <xref target="resumption-and-psk"/>.
+Because TLS 1.3
 changes the way keys are derived, it updates <xref target="RFC5705"/> as
 described in <xref target="exporters"/>. It also changes how Online
 Certificate Status Protocol (OCSP) messages are carried and therefore updates
@@ -1291,7 +1290,7 @@ handshake with an "illegal_parameter" alert if the value changes.</t>
        server_name(0),                             /* RFC 6066 */
        max_fragment_length(1),                     /* RFC 6066 */
        status_request(5),                          /* RFC 6066 */
-       supported_groups(10),                       /* RFC 4492, 7919 */
+       supported_groups(10),                       /* RFC 8422, 7919 */
        signature_algorithms(13),                   /* RFC 8446 */
        use_srtp(14),                               /* RFC 5764 */
        heartbeat(15),                              /* RFC 6520 */
@@ -1808,7 +1807,7 @@ the named groups which the client supports for key exchange, ordered
 from most preferred to least preferred.</t>
 
 <t>Note: In versions of TLS prior to TLS 1.3, this extension was named
-"elliptic_curves" and only contained elliptic curve groups. See <xref target="RFC4492"/> and
+"elliptic_curves" and only contained elliptic curve groups. See <xref target="RFC8422"/> and
 <xref target="RFC7919"/>. This extension was also used to negotiate
 ECDSA curves. Signature algorithms are now negotiated independently (see
 <xref target="signature-algorithms"/>).</t>
@@ -4955,21 +4954,16 @@ requested, and only IETF Standards Track RFCs can request a value of "Y".</t>
 <seriesInfo name='DOI' value='10.17487/RFC4366'/>
 </reference>
 
-<!-- If the 4492bis doc. is published before this one, should we note
-  somewhere in text that we're aware of it (possibly the last paragraph
-  of the Introduction)? -->
-<reference  anchor='RFC4492' target='https://www.rfc-editor.org/info/rfc4492'>
+<reference  anchor='RFC8422' target='https://www.rfc-editor.org/info/rfc8422'>
 <front>
-<title>Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)</title>
-<author initials='S.' surname='Blake-Wilson' fullname='S. Blake-Wilson'><organization /></author>
-<author initials='N.' surname='Bolyard' fullname='N. Bolyard'><organization /></author>
-<author initials='V.' surname='Gupta' fullname='V. Gupta'><organization /></author>
-<author initials='C.' surname='Hawk' fullname='C. Hawk'><organization /></author>
-<author initials='B.' surname='Moeller' fullname='B. Moeller'><organization /></author>
-<date year='2006' month='May' />
+<title>Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS) Versions 1.2 and Earlier</title>
+<author initials='Y.' surname='Nir' fullname='Y. Nir'><organization /></author>
+<author initials='S.' surname='Josefsson' fullname='S. Josefsson'><organization /></author>
+<author initials='M.' surname='Pegourie-Gonnard' fullname='M. Pegourie-Gonnard'><organization /></author>
+<date year='2018' month='August' />
 </front>
-<seriesInfo name='RFC' value='4492'/>
-<seriesInfo name='DOI' value='10.17487/RFC4492'/>
+<seriesInfo name='RFC' value='8422'/>
+<seriesInfo name='DOI' value='10.17487/RFC8422'/>
 </reference>
 
 <reference  anchor='RFC5077' target='https://www.rfc-editor.org/info/rfc5077'>
@@ -6222,7 +6216,7 @@ from older TLS implementations.</t>
        server_name(0),                             /* RFC 6066 */
        max_fragment_length(1),                     /* RFC 6066 */
        status_request(5),                          /* RFC 6066 */
-       supported_groups(10),                       /* RFC 4492, 7919 */
+       supported_groups(10),                       /* RFC 8422, 7919 */
        signature_algorithms(13),                   /* RFC 8446 */
        use_srtp(14),                               /* RFC 5764 */
        heartbeat(15),                              /* RFC 6520 */


### PR DESCRIPTION
It also limits its scope to TLS 1.2 and below, so we do not need to
Update: it anymore.  Remove text discussing the update, and use the
new reference as appropriate.

Retain "coauthor of RFC 4492" in the contributors section.